### PR TITLE
ci(actions): trim Go matrix, add concurrency + retention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,20 @@ name: CI
 on:
   push:
     branches: [ main, develop ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
   pull_request:
     branches: [ main, develop ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -12,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.25', '1.26']
+        go-version: ${{ github.event_name == 'pull_request' && fromJSON('["1.26"]') || fromJSON('["1.25", "1.26"]') }}
 
     steps:
     - name: Checkout code
@@ -91,6 +103,7 @@ jobs:
       with:
         name: security-scan-results
         path: verdict-results.json
+        retention-days: 7
       if: always()
 
   dep-go-version-drift:


### PR DESCRIPTION
## Summary
- PRs test Go 1.26 only; push to main still validates 1.25 + 1.26.
- Add concurrency.cancel-in-progress to kill duplicate runs on rapid pushes.
- Add paths-ignore for **.md, docs/**, LICENSE.
- Cap security-scan-results artifact retention to 7 days.

Part of cross-repo Actions cost optimization sweep.

## Test plan
- [ ] CI passes on this branch
- [ ] PR test run validates against Go 1.26 only